### PR TITLE
Corrigida erro na chamada da requisição de compras de um material

### DIFF
--- a/frontend/src/components/materiais/Materiais.jsx
+++ b/frontend/src/components/materiais/Materiais.jsx
@@ -238,7 +238,7 @@ export default class Materiais extends Component {
         let componenteAtual = this;
         axios({
             method: 'get',
-            url: 'https://projetolabengapi.azurewebsites.net/api/material/' + idMaterial,
+            url: 'https://projetolabengapi.azurewebsites.net/api/compraMateriais/material/' + idMaterial,
             headers: {
                 'Content-Type': 'application/json; charset=utf-8'
             }

--- a/frontend/src/components/membros/Arquivados.jsx
+++ b/frontend/src/components/membros/Arquivados.jsx
@@ -118,7 +118,11 @@ export default class Ativos extends Component {
             return (
                 <tr key={membro.id}>
                     <td>{membro.nome}</td>
-                    <td>{membro.grupos.map(grupo => {return grupo.nome + ", "})}</td>
+                    <td>
+                        {membro.grupos.length === 0 ? "Membro sem grupo!" : membro.grupos.map(grupo => {
+                            return grupo.nome + ", " 
+                        })}
+                    </td>
                     <td>{membro.status}</td>
                     <td>
                         <button type="button" className="btn btn-success" data-toggle="modal" data-target={"#reativarMembro-" + membro.id}>

--- a/frontend/src/components/membros/Ativos.jsx
+++ b/frontend/src/components/membros/Ativos.jsx
@@ -334,7 +334,11 @@ export default class Ativos extends Component {
             return (
                 <tr key={membro.id}>
                     <td>{membro.nome}</td>
-                    <td>{membro.grupos.map(grupo => {return grupo.nome + ", "})}</td>
+                    <td>
+                        {membro.grupos.length === 0 ? "Membro sem grupo!" : membro.grupos.map(grupo => {
+                            return grupo.nome + ", " 
+                        })}
+                    </td>
                     {/* <td>{membro.mensalidade}</td> */}
                     <td>{membro.status}</td>
                     <td>


### PR DESCRIPTION
Foi corrigido um erro que estava sendo gerado na chamada da requisição de listar compras de um material. Além disso, acrescentado uma verificação que mostra quando um membro está sem grupo, tanto em membros Ativos, quanto em Desativados.